### PR TITLE
/e/OS: "EXIF metadata stripping for photos"

### DIFF
--- a/android_comparison.htm
+++ b/android_comparison.htm
@@ -748,7 +748,7 @@ font-size: x-small;
 <td class="red">No</td>
 <td class="red">No</td>
 <td class="red">No</td>
-<td class="red">No</td>
+<td class="yellow">Can be changed</td>
 <td class="red">No</td>
 <td class="red">No</td>
 </tr>


### PR DESCRIPTION
/e/OS Camera is forked[1] from OpenCamera, that allows[2] to remove EXIF data[3].

[1]: https://gitlab.e.foundation/e/os/camera
[2]: https://opencamera.org.uk/help.html
[3]: https://gitlab.e.foundation/e/os/camera/-/blob/master/app/src/main/res/values/strings.xml#L1016