### PR TITLE
os_familytree.htm: Bring back horizontal scrolling

### DIFF
--- a/os_familytree.htm
+++ b/os_familytree.htm
@@ -25,10 +25,7 @@ Currently, the family tree includes between around 1,120 different operating sys
 
 <p><strong>There are some missing system and some corrections that are not included in the graphic below yet. <a href="https://github.com/eylenburg/eylenburg.github.io/issues/80" target"_blank">Please see here for the issue tracker.</a></strong></p>
 
-<a href="pics/Eylenburg_Operating_System_Timeline_Family_Tree.svg" target="_blank"><p style="font-size: x-large;">Click here to open the picture in a new tab for horizontal scrolling</p></a>
-<div style="width: 100%; overflow-x: auto; white-space: nowrap;">
-<object type="image/svg+xml" data="pics/Eylenburg_Operating_System_Timeline_Family_Tree.svg" style="min-width: 2270px; display: block;"></object>
-</div>
+<object type="image/svg+xml" data="pics/Eylenburg_Operating_System_Timeline_Family_Tree.svg"></object>
 
 <p><strong>If anyone would like to make corrections, please feel tell me.</strong><br />
 <i>Big Update August 2021: Thank you for everyone e-mailing me with suggestions after this webpage got posted on Hackernews by someone. I have added most of the suggestions, such as missing operating systems and a few mistakes.</i><br />


### PR DESCRIPTION
Hello eylenburg

I am referencing issue [#96](https://github.com/eylenburg/eylenburg.github.io/issues/96) (Fix missing horizontal scrolling in OS Family Tree).

I have found the bug and fixed it. The cause was the styling which caused the image not to extend beyond the edge of the screen and thus the scrollbar to appear somewhat hidden further down. I have removed this styling.
I have removed the link to the image for horizontal scrolling, as this is no longer needed. If you still want to keep it, I can also put it back in.

I hope that this merge request solves your problem as expected.

Best regards
Timon