### PR TITLE
OS family tree: Sticky timeline bugfixes

### DIFF
--- a/os_familytree.htm
+++ b/os_familytree.htm
@@ -16,6 +16,7 @@
     }
 
     .timeline-table {
+        color: black;
         display: flex;
         height: 30px;
         white-space: nowrap;
@@ -23,7 +24,7 @@
     }
 
     .timeline-table div {
-        width: 29.018px;
+        flex: 1;
         text-align: center;
         border-right: 1px solid #ccc;
         line-height: 30px;
@@ -33,6 +34,7 @@
 
     .timeline-table div:last-child {
         border-right: none;
+        margin-right: 20px;
     }
 
     #toggleButton {

--- a/os_familytree.htm
+++ b/os_familytree.htm
@@ -72,6 +72,8 @@ Currently, the family tree includes between around 1,120 different operating sys
 
 <button id="toggleButton" class="active">Disable sticky timeline</button>
 
+<br>
+
 <div class="year-header">
     <div class="timeline-table" id="timelineTable"></div>
 </div>


### PR DESCRIPTION
Hello Eylenburg

The sticky timeline which I integrated into the os family tree yesterday still had some errors in certain scenarios. I was able to correct these.

Best regards Timon


The following errors have been fixed:
**Button bug:**
![Button_Bug](https://github.com/user-attachments/assets/8d550496-23a5-4954-a0f5-45ede39df174)

**Darkmode contrast:**
![Darkmode_Bug](https://github.com/user-attachments/assets/4fe89418-7fcb-4a52-b70d-836ddaf14415)

**Scaling problems:**
![Skale_Bug](https://github.com/user-attachments/assets/2bb307ec-1a97-4846-b7bd-38f3cac806e4)
