### PR TITLE
android_comparison: fix typo from last update

### DIFF
--- a/android_comparison.htm
+++ b/android_comparison.htm
@@ -197,7 +197,7 @@ font-size: x-small;
   
 <h2 class="center">Comparison of Android-based Operating Systems</h2>
 <p class="center">Source: eylenburg.github.io</p>
-<p class="center" style="color: red; font-size: small;">Last updated: 3 January 2024</p>
+<p class="center" style="color: red; font-size: small;">Last updated: 3 January 2025</p>
 
 <table class="comparison">
 


### PR DESCRIPTION
Last update was in 2025, but 2024 was kept