### PR TITLE
Update android_comparison.htm

### DIFF
--- a/android_comparison.htm
+++ b/android_comparison.htm
@@ -902,7 +902,7 @@ WHITE<br />
 <td class="legend">Auto-reboot timer for locked devices</td>
 <td class="green">Yes</td>
 <td class="yellow tooltip">Yes, with flaws (no proper BFU state)<span class="tooltiptext">CalyxOS has a disabled-by-default port of an older GrapheneOS implementation of the auto-reboot feature, which was determined to not be as robust due to being able to bypass it by crashing <code>system_server</code>. It also lacks the memory clearing required to get the device properly back at rest for reboots. Therefore it can't return the device to a proper BFU (before first unlock) state like the GrapheneOS and iOS implementations.</span></td>
-<td class="red">No</td>
+<td class="red">Yes</td>
 <td class="red">No</td>
 <td class="red">No</td>
 <td class="yellow tooltip">Advanced Protection mode, with flaws<span class="tooltiptext">If Advanced Protection Mode is enabled, it provides a 72 hour auto-reboot timer. However, it appears to lack memory zeroing and therefore can't return the device to a proper BFU (before first unlock) state like the GrapheneOS and iOS implementations. It is unclear if the implementation is protected from a core system process crashing (<code>system_server</code>) preventing a trigger of the auto-reboot.</span></td>
@@ -1199,6 +1199,7 @@ The below is a non-comprehensive list of mobile operating systems, both those yo
 
 </body>
 </html>
+
 
 
 


### PR DESCRIPTION
Changed Auto-reboot timer for locked devices for iodeOS as it was added in the last update. "Auto-reboot timeout (v5 and v6)"
see: 
https://gitlab.iode.tech/ota/news/-/blob/dev/posts.json?ref_type=heads Line 2733