### PR TITLE
Replace Mull browser mention with IronFox on the browser comparison table

### DIFF
--- a/browser_comparison.htm
+++ b/browser_comparison.htm
@@ -3074,7 +3074,7 @@ https://github.com/gorhill/uBlock/wiki/uBlock-Origin-works-best-on-Firefox</span
 <tr><td colspan="20" style="font-weight: bold; font-size: larger;">Other notable, still developed browsers which were not included in this comparison (list not exhaustive):</td></tr>
 <tr><td colspan="20"><span style="text-decoration: underline;">Using Blink/V8 engine:</span> Samsung Browser, ungoogled-chromium, Falkon, Yandex Browser <em>(except iOS)</em>, Naver Whale <em>(except iOS)</em>, DuckDuckGo Browser <em>(Android)</em>, Cromite, Vanadium, <em>seemingly all Chinese browsers</em> (e.g. 360 Secure, Baidu, CM, Maxthon, QQ, Sogou, UC), <em>many more...</em></td></tr>
 <tr><td colspan="20"><span style="text-decoration: underline;">Using WebKit/Nitro engine:</span> GNOME Web, Otter, Orion, DuckDuckGo Browser <em>(macOS/iOS)</em>, Yandex Browser <em>(iOS)</em>, Naver Whale <em>(iOS)</em>, <em>all iOS browsers...</em></td></tr>
-<tr><td colspan="20"><span style="text-decoration: underline;">Using Gecko/SpiderMonkey engine:</span> Floorp, Waterfox, LibreWolf, Mullvad Browser, Fennec F-Droid, Mull, SeaMonkey, Tor Browser,  ...</td></tr>
+<tr><td colspan="20"><span style="text-decoration: underline;">Using Gecko/SpiderMonkey engine:</span> Floorp, Waterfox, LibreWolf, Mullvad Browser, Fennec F-Droid, IronFox, SeaMonkey, Tor Browser,  ...</td></tr>
 <tr><td colspan="20"><span style="text-decoration: underline;">Using Goanna/SpiderMonkey engine:</span> Pale Moon, Basilisk, K-Meleon, ...</td></tr>
 <tr><td colspan="20"><span style="text-decoration: underline;">Using other engines:</span> <span class="tooltip">NetSurf<span class="tooltiptext">using Hubbub/Duktape engine</span></span>, Ekioh Flow, Ladybird, <span class="tooltip">iBrowse<span class="tooltiptext">for AmigaOS/MorphOS</span></span>, Servo, <em>text browsers...</em></td></tr>
 </tfoot>
@@ -3085,5 +3085,6 @@ https://github.com/gorhill/uBlock/wiki/uBlock-Origin-works-best-on-Firefox</span
 <script src="bottom.js "></script>
 </body>
 </html>
+
 
 


### PR DESCRIPTION
Mull is unmaintained, and IronFox is its successor