### PR TITLE
Firefox Android doesn’t seem to have site isolation anymore

### DIFF
--- a/browser_comparison.htm
+++ b/browser_comparison.htm
@@ -79,7 +79,7 @@ The result of the comparison is less clear than last time. In terms of pure feat
 
 <h2 class="center">Comparison of Web Browsers</h2>
 <p class="center">Source: eylenburg.github.io</p>
-<p class="center" style="color: red; font-size: small;">Last updated: 14 January 2026</p>
+<p class="center" style="color: red; font-size: small;">Last updated: 2 March 2026</p>
 <p style="font-size: 75%; font-style: italic;"> This table is best viewed on a monitor with 1920px width (Full HD) with 100% display scaling.</p>
 
 <input id="desktop" type="checkbox" checked /><label for="desktop"> Show Desktop browsers</label>
@@ -3085,6 +3085,7 @@ https://github.com/gorhill/uBlock/wiki/uBlock-Origin-works-best-on-Firefox</span
 <script src="bottom.js "></script>
 </body>
 </html>
+
 
 
 


### PR DESCRIPTION
147.0.2 disabled Fission again and they didn't even mention it in the release notes: https://bugzilla.mozilla.org/show_bug.cgi?id=2011886

I’m not familiar navigating in Bugzilla, so I can’t tell if they reenabled Fission

