### PR TITLE
Update all cloud comparison prices

### DIFF
--- a/cloud_comparison.htm
+++ b/cloud_comparison.htm
@@ -1386,7 +1386,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <li><strong>Microsoft 365</strong> (OneDrive &amp; Outlook.com) (&euro;99 p.a. for 1 TB files and 100 GB mail) <span class="bad">Big Tech</span>   <span class="bad">No privacy</span>  <span class="bad">Incompatible with Linux</span></li>
 <!-- <li><em>Further choices:</em><ul>
 <li><strong>GMX/Mail.com</strong> (&euro;96 p.a. for 500 GB files and 65 GB mail)   <span class="bad">No privacy</span> <span class="bad">No sync client</span> - if you care more about mail and PIM rather than file sync</li>
-<li><strong>Yandex</strong> (&euro;89 p.a. for 1 TB files and unlimited mail storage.) <span class="bad">No privacy</span> - if you'd rather give your data to the Russians than the Americans</li> -->
+<li><strong>Yandex</strong> (&euro;89 p.a. for 1 TB files and unlimited mail storage) <span class="bad">No privacy</span> - if you'd rather give your data to the Russians than the Americans</li> -->
 </ul>
 </ul>
 

--- a/cloud_comparison.htm
+++ b/cloud_comparison.htm
@@ -157,7 +157,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 
 <h2 class="center">Comparison of Cloud, Sync &amp; Email services</h2>
 <p class="center">Source: eylenburg.github.io</p>
-<p class="center" style="color: red; font-size: small;">Last updated: 24 April 2026</p>
+<p class="center" style="color: red; font-size: small;">Last updated: 18 May 2026</p>
 <p style="font-size: 75%; font-style: italic;"> This table is best viewed on a monitor with 1920px width (Full HD) with 100% display scaling.</p>
 
 
@@ -180,7 +180,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td colspan="6" rowspan="2">File sync</td>
 <td colspan="3" rowspan="2">Addressbook, Calendar &amp; Tasks</td>
 <td colspan="3" rowspan="2">Email</td>
-<td colspan="5">Pricing<span style="font-size: smaller;"> (single user, annual price in EUR)<span style="color: red;"> (prices last updated in 2022)</span></span></td>
+<td colspan="5">Pricing<span style="font-size: smaller;"> (single user, annual price in EUR, VAT excluded)<span style="color: red;"> (prices last updated in May 2026)</span></span></td>
 </tr>
 
 <tr style="text-align: left; vertical-align: top;">
@@ -317,8 +317,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM --><!-- Mail -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;108<br />(100 GB)</td>
+<td class="px">free<br />(10 GB)</td>
+<td colspan="2" class="px">&euro;108<br />(100 GB)</td>
 <td class="px tooltip">&euro;486<br />(unlimited)<span class="tooltiptext">only available for Team subscription with 3 users minimum</span></td>
 <td>Unlimited plan shows price for 3 users (minimum amount).</td><!-- price comment -->
 </tr>
@@ -364,8 +364,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM --><!-- Mail -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td colspan="2" class="px">&euro;120<br />(2 TB)</td>
+<td colspan="4" class="px">&euro;120<br />(2 TB)</td>
 <td>Family plan also available.</td><!-- price comment -->
 </tr>
 
@@ -415,10 +414,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px tooltip">&euro;44<br />(30 GB)<span class="tooltiptext">additional 10 GB for files</span></td>
-<td class="px tooltip">&euro;160<br />(100 GB)<span class="tooltiptext">additional 200 GB for emails</span></td>
-<td class="px na"></td>
-<td></td><!-- price comment -->
+<td colspan="2" class="px tooltip">&euro;60<br />(10 GB)<span class="tooltiptext">also includes 50 GB for mail storage</span></td>
+<td colspan="2" class="px na"></td>
+<td>Personal plan offers 50 GB for mail, calendar and contacts, and 10 GB for file storage. Family and duo plans are also offered.</td><!-- price comment -->
 </tr>
 
 <tr class="product NoMSO NoSelfHosting NoPIM NoPIMEncrypt NoDAV NoEmail NoEmailEncrypt NoIMAP">
@@ -466,8 +464,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
 <td class="px">&euro;31<br />(10 GB)</td>
-<td class="px">&euro;61<br />(20 GB)</td>
-<td class="px">&euro;310<br />(100 GB)</td>
+<td class="px">&euro;62<br />(20 GB)</td>
+<td class="px">&euro;309<br />(100 GB)</td>
 <td class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
@@ -549,9 +547,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px">free<br />(65 GB)</td>
-<td class="px tooltip">&euro;24<br />(100 GB)<span class="tooltiptext">additional 65 GB for emails</span></td>
-<td class="px tooltip">&euro;179<br />(1 TB)<span class="tooltiptext">additional 65 GB for emails</span></td>
+<td colspan="2" class="px tooltip">free<br />(65 GB)<span class="tooltiptext">additional 2 GB for >50MB attachments</span></td>
+<td colspan="2" class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -573,9 +570,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM, Mail, Other -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;22<br />(150 GB)</td>
-<td class="px">&euro;50<br />(1 TB)</td>
+<td class="px">free<br />(10 GB)</td>
+<td colspan="3" class="px">&euro;99<br />(2 TB)</td>
 <td>Lifetime purchase options also available.</td><!-- price comment -->
 </tr>
 
@@ -603,9 +599,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px">free<br />(20 GB)</td>
-<td colspan="2" class="px">&euro;60<br />(2 TB)</td>
-<td>Family plan also available</td><!-- price comment -->
+<td colspan="2" class="px tooltip">free<br />(15 GB)<span class="tooltiptext">additional 20 GB for emails</span></td>
+<td colspan="2" class="px">&euro;79<br />(3 TB)</td>
+<td>Paid plans offer unlimited storage for emails</td><!-- price comment -->
 </tr>
 
 <tr class="product NoMSO NoAndroidSync NoPIM NoPIMEncrypt NoDAV NoEmail NoEmailEncrypt NoIMAP">
@@ -627,9 +623,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM, Mail, Other -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;42<br />(100 GB)</td>
-<td class="px">&euro;108<br />(2 TB)</td>
+<td colspan="4" class="px">&euro;120<br />(1 TB)</td>
 <td>Lifetime purchase options also available.</td><!-- price comment -->
 </tr>
 
@@ -657,9 +651,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">&euro;120<br />(5 GB)<span class="tooltiptext">only email (without files, calendar etc.) for &euro;57 p.a.</span></td>
-<td class="px">&euro;142<br />(15 GB)</td>
-<td class="px">&euro;385<br />(100 GB)</td>
+<td class="px tooltip">&euro;130<br />(5 GB)<span class="tooltiptext">only email (without files, calendar etc.) for &euro;65 p.a.</span></td>
+<td class="px tooltip">&euro;163<br />(15 GB)<span class="tooltiptext">only email (without files, calendar etc.) for &euro;98 p.a.</span></td>
+<td class="px tooltip">&euro;442<br />(100 GB)<span class="tooltiptext">only email (without files, calendar etc.) for &euro;377 p.a.</span></td>
 <td class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
@@ -683,9 +677,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
 <td class="px">free<br />(10 GB)</td>
-<td class="px">&euro;12<br />(25 GB)</td>
-<td class="px">&euro;24<br />(100 GB)</td>
-<td class="px">&euro;120<br />(1 TB)</td>
+<td class="px">&euro;12<br />(35 GB)</td>
+<td class="px">&euro;24<br />(110 GB)</td>
+<td class="px">&euro;120<br />(1.01 TB)</td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -708,10 +702,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM, Mail, Other -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;36<br />(250 GB)</td>
-<td class="px">&euro;120<br />(2 TB)</td>
-<td></td><!-- price comment -->
+<td colspan="4" class="px na"></td>
+<td>Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;90 for 1 TB HDD) or ~&euro;40 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
 </tr>
 
 
@@ -739,10 +731,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes <em><span class="tooltip">(needs PGP support in client)<span class="tooltiptext">To use encrypted mail (zero access encryption), the user will need to decrypt them on the local device, e.g. using Thunderbird, or the OpenKeychain app on Android</span></span></em></td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px">&euro;36<br />(10 GB)</td>
-<td class="px">&euro;46<br />(15 GB)</td>
-<td class="px tooltip">&euro;121<br />(100 GB)<span class="tooltiptext">also includes 10 GB mail storage</span></td>
-<td class="px tooltip">&euro;538<br />(1 TB)<span class="tooltiptext">also includes 25 GB mail storage</span></td>
+<td class="px tooltip">&euro;30<br />(5 GB)<span class="tooltiptext">Standard plan. Also includes 10 GB for mail storage</span></td>
+<td class="px tooltip">&euro;40<br />(15 GB)<span class="tooltiptext">Standard plan. Also includes 10 GB for mail storage</span></td>
+<td class="px tooltip">&euro;114<br />(100 GB)<span class="tooltiptext">Premium plan. Also includes 25 GB for mail storage</span></td>
+<td class="px tooltip">&euro;546<br />(1 TB)<span class="tooltiptext">Premium plan. Also includes 25 GB for mail storage</span></td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -770,9 +762,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">&euro;30<br />(5 GB)<span class="tooltiptext">also includes 12 GB for files</td>
-<td class="px tooltip">&euro;90<br />(20 GB)<span class="tooltiptext">also includes 24 GB for files</td>
-<td colspan="2" class="px na">max. 70 GB (&euro;300)</td>
+<td class="px tooltip">&euro;30<br />(6 GB)<span class="tooltiptext">also includes 5 GB for mail storage</td>
+<td class="px tooltip">&euro;42<br />(30 GB)<span class="tooltiptext">also includes 10 GB for mail storage</td>
+<td colspan="2" class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -795,9 +787,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM --><!-- Mail --><!-- Other -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;50<br />(400 GB)</td>
-<td class="px">&euro;100<br />(2 TB)</td>
+<td colspan="2" class="px">free<br />(20 GB)</td>
+<td class="px tooltip">&euro;40<br />(200 GB)</td>
+<td class="px tooltip">&euro;100<br />(3 TB)</td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -827,10 +819,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px">free<br />(15 GB)</td>
-<td class="px">&euro;24<br />(100 GB)</td>
-<td class="px tooltip">&euro;69<br />(1 TB)<span class="tooltiptext">Mail storage also upgraded from 15 GB to 50 GB</span></td>
-<td>Family plan also available. 1 TB plan includes Microsoft Office Online.</td><!-- price comment -->
+<td class="px tooltip">free<br />(5 GB)<span class="tooltiptext">also includes 15 GB for mail storage</span></td>
+<td colspan="2" class="px tooltip">&euro;20<br />(100 GB)<span class="tooltiptext">also includes 100 GB for mail storage</span></td>
+<td class="px tooltip">&euro;99<br />(1 TB)<span class="tooltiptext">also includes 100 GB for mail storage</span></td>
+<td>Family plan for 1-6 users also available. 1 TB plan & Family plan include Copilot (in case of the family plan, for subscription owner only) and Microsoft Office Online.</td><!-- price comment -->
 </tr>
 
 <tr class="product NoE2EE NoFullE2EE NoPIMEncrypt NoEmailEncrypt">
@@ -860,7 +852,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td colspan="2" class="px">&euro;20<br />(20 GB)</td>
 <td class="px">&euro;60<br />(128 GB)</td>
 <td class="px">&euro;130<br />(1 TB)</td>
-<td>Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;50 for 1 TB HDD) or ~&euro;60 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
+<td>Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;90 for 1 TB HDD) or ~&euro;40 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
 </tr>
 
 <tr class="product NoPIMEncrypt NoFullE2EE NoEmail NoEmailEncrypt NoIMAP">
@@ -889,13 +881,13 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <span class="tooltip">Hetzner <span class="tooltiptext">Storage Share</span></span>:<br />
 <span class="tooltip">Ionos <span class="tooltiptext">Managed Nextcloud</span></span>:<br />
 <span class="tooltip">Hosting.de <span class="tooltiptext">Managed Nextcloud</span></span>:</td>
-<td class="px" style="vertical-align: top;">&euro;56<br />&euro;72<br />&euro;59</td>
-<td class="px" style="vertical-align: top;">&euro;56<br />&euro;108<br />&euro;119</td>
+<td class="px" style="vertical-align: top;">&euro;51<br />&euro;72<br />&euro;59</td>
+<td class="px" style="vertical-align: top;">&euro;51<br />&euro;108<br />&euro;119</td>
 <!-- <td colspan="2" class="px tooltip">~&euro;15-59<br />(100 GB)<span class="tooltiptext">Owncube (single-user): &euro;15<br />Hetzner Storage Share (multi-user): &euro;41<br />Hosting.de Managed Nextcloud (multi-user): &euro;59</td>
 <td class="px tooltip">~&euro;70-83<br />(500 GB)<span class="tooltiptext">Hetzner Storage Share (multi-user): &euro;70<br />Ionos Managed Nextcloud (multi-user): &euro;72<br />Hosting.de Managed Nextcloud (multi-user): &euro;83</td>
 <td class="px tooltip">~&euro;50-119<br />(1 TB)<span class="tooltiptext">Owncube (single-user): &euro;15<br />Hetzner Storage Share (multi-user): &euro;113<br />Ionos Managed Nextcloud (multi-user): &euro;108<br />Hosting.de Managed Nextcloud (multi-user): &euro;119</td>
 <td class="px tooltip">~&euro;70-299<br />(2 TB)<span class="tooltiptext">Owncube (single-user): &euro;70<br />Hetzner Storage Share (multi-user): &euro;141<br />Hosting.de Managed Nextcloud (multi-user): &euro;299</td> -->
-<td>Can be shared by multiple users. Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;50 for 1 TB HDD) or ~&euro;60 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
+<td>Can be shared by multiple users. Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;90 for 1 TB HDD) or ~&euro;40 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
 </tr>
 
 <tr class="product NoMSO NonFree NoSelfHosting NoLinuxApp NoAndroidSync NoPIM NoPIMEncrypt NoDAV NoEmail NoEmailEncrypt NoIMAP">
@@ -916,9 +908,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM --><!-- Mail & Notes -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;34<br />(500 GB)</td>
-<td class="px">&euro;85<br />(2 TB)</td>
+<td colspan="3" class="px">&euro;30<br />(500 GB)</td>
+<td class="px">&euro;72<br />(2 TB)</td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -940,8 +931,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM, Mail, Other -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;50<br />(500 GB)</td>
+<td colspan="3" class="px">&euro;50<br />(500 GB)</td>
 <td class="px">&euro;100<br />(2 TB)</td>
 <td>Family plan and lifetime purchase options also available.</td><!-- price comment -->
 </tr>
@@ -971,8 +961,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="na"></td><!-- IMAP -->
 <td class="na"></td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td class="px">&euro;41<br />(200 GB)</td>
+<td colspan="3" class="px">&euro;41<br />(200 GB)</td>
 <td class="px">&euro;111<br />(1 TB)</td>
 <td>Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;50 for 1 TB HDD) or ~&euro;60 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
 </tr>
@@ -997,9 +986,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="no">No</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px">&euro;21<br />(5 GB)</td>
-<td class="px">&euro;51<br />(15 GB)</td>
-<td colspan="2" class="px na"></td>
+<td class="px">&euro;15<br />(5 GB)</td>
+<td class="px">&euro;45<br />(15 GB)</td>
+<td colspan="2" class="px na">max. 50 GB (&euro;150)</td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -1028,10 +1017,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="almost"><span class="tooltip">Desktop only<span class="tooltiptext">Windows, macOS, Linux</span></span><em> (via Proton&shy;Mail Bridge)</em></td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px" colspan="2">&euro;42<br />(15 GB)</td>
-<td class="px">&euro;96<br />(500 GB)</td>
+<td class="px tooltip">free<br />(5 GB)<span class="tooltiptext">also includes 1 GB for mail storage</span></td>
+<td colspan="2" class="px tooltip">&euro;48<br />(200 GB)<span class="tooltiptext">also includes 1 GB for mail storage</span></td>
 <td class="px na"></td>
-<td></td><!-- price comment -->
+<td>Proton also offers a 500GB plan for 120€ p.a. which also includes Proton Suite (Mail, VPN, Password Manager, AI Chatbot). Family and duo plans are also offered.</td><!-- price comment -->
 </tr>
 
 <tr class="product NoMSO NoFiles NoE2EE NoFullE2EE NoLinuxApp NoAndroidSync NoPIMEncrypt NoEmail NoEmailEncrypt  NoIMAP">
@@ -1079,9 +1068,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">&euro;30<br />(10 GB)<span class="tooltiptext">additional 1 GB for files</span></td>
-<td class="px tooltip">&euro;40<br />(25 GB)<span class="tooltiptext">additional 2 GB for files</span></td>
-<td class="px tooltip">&euro;825<br />(100 GB)<span class="tooltiptext">additional 50 GB for emails</span></td>
+<td class="px tooltip">&euro;35<br />(10 GB)<span class="tooltiptext">additional 1 GB for files</span></td>
+<td class="px tooltip">&euro;50<br />(25 GB)<span class="tooltiptext">additional 2 GB for files</span></td>
+<td class="px tooltip">&euro;120<br />(100 GB)<span class="tooltiptext">additional 10 GB for files</span></td>
 <td class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
@@ -1106,10 +1095,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
 <td colspan="2" class="px" style="vertical-align: top;">
-<em>Single user prices:</em><br />Luckycloud:<br />YourSecureCloud:<br /></td>
-<td class="px" style="vertical-align: top;"><br />&euro;86<br />&euro;96<br /></td>
-<td class="px" style="vertical-align: top;"><br />&euro;426<br />&euro;600<br /></td>
-<td>Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;50 for 1 TB HDD) or ~&euro;60 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
+<em>Single user prices:</em><br />Luckycloud:<br /></td>
+<td class="px" style="vertical-align: top;"><br />&euro;86<br /></td>
+<td class="px" style="vertical-align: top;"><br />&euro;426<br /></td>
+<td>Self-hosted cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;90 for 1 TB HDD) or ~&euro;40 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
 </tr>
 
 <!--
@@ -1136,7 +1125,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="no">No</td>
 
 <td class="px">Free<br />(10 GB)</td>
-<td colspan="2" class="px">&euro; 96<br />(100 GB mail + 100 GB files)</td>
+<td colspan="2" class="px">&euro; 96<br />(100 GB for mail + 100 GB files)</td>
 <td class="px na"></td>
 <td></td>
 </tr>
@@ -1162,8 +1151,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px">&euro;53<br />(10 GB)</td>
-<td colspan="3" class="px na"></td>
+<td colspan="2" class="px">&euro;60<br />(20 GB)</td>
+<td colspan="2" class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -1186,8 +1175,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM, Mail, Other -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px na"></td>
-<td colspan="2" class="px">&euro;85<br />(2 TB)</td>
+<td colspan="3" class="px">&euro;36<br />(150 GB)</td>
+<td class="px">&euro;124<br />(1 TB)</td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -1212,7 +1201,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="na" style="border-left: double black;"></td><td class="na"></td><td class="na" style="border-left: none;"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
 <td colspan="4" class="px na" style="border-left: double black;"></td>
-<td>Self-hosted server cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;50 for 1 TB HDD) or ~&euro;60 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
+<td>Self-hosted server cost: either hardware upfront costs (~&euro;50 for RaspPi + ~&euro;90 for 1 TB HDD) or ~&euro;40 p.a. for cheap VPS (e.g. 1 TB at AlphaVPS)</td><!-- price comment -->
 </tr>
 
 
@@ -1234,9 +1223,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <!-- PIM, Mail, Other -->
 <td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td><td class="na"></td>
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="na px"></td>
-<td class="px">&euro;100<br />(500 GB)</td>
-<td class="px">&euro;240<br />(2.5 TB)</td>
+<td colspan="2" class="px">&euro;48<br />(50 GB)</td>
+<td colspan="2" class="px">&euro;120<br />(1 TB)</td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -1260,9 +1248,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="no">No</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px">&euro;36<br />(11 GB)</td>
-<td class="px">&euro;132<br />(101 GB)</td>
-<td colspan="2" class="px na"></td>
+<td colspan="2" class="px">&euro;36<br />(20 GB)</td>
+<td class="px">&euro;96<br />(500 GB)</td>
+<td class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -1290,11 +1278,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes <em><span class="tooltip">(needs PGP support in client)<span class="tooltiptext">To use encrypted mail (zero access encryption), the user will need to decrypt them on the local device, e.g. using Thunderbird, or the OpenKeychain app on Android</span></span></em></td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px">&euro;206<br />(5 GB)</td>
+<td class="px">&euro;66<br />(10 GB)</td>
+<td colspan="2" class="px">&euro;197<br />(100 GB)</td>
 <td class="px na"></td>
-<td class="px">&euro;401<br />(200 GB)</td>
-<td class="px na"></td>
-<td>Family plan also offered. Cloud and Mail have to be purchased separately.</td><!-- price comment -->
+<td>Family plan is also offered. Cloud and Mail have to be purchased separately.</td><!-- price comment -->
 </tr>
 
 <tr class="product NoMSO NonFree NoSelfHosting NoFiles NoE2EE NoFullE2EE NoLinuxApp NoAndroidSync NoPIMEncrypt NoEmailEncrypt">
@@ -1316,8 +1303,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="no">No</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px">free<br />(1 TB)</td>
-<td colspan="2" class="px na"></td>
+<td colspan="2" class="px">free<br />(15 GB)</td>
+<td class="px">&euro;30<br />(100 GB)</td>
+<td class="px">&euro;120<br />(1 TB)</td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -1346,10 +1334,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px">free<br />(unlimited)</td>
-<td class="px">&euro;18<br />(100 GB)</td>
-<td class="px">&euro;89<br />(1 TB)</td>
-<td></td><!-- price comment -->
+<td colspan="3" class="px">&euro;22<br />(200 GB)</td>
+<td class="px">&euro;25<br />(1 TB)</td>
+<td>Family plan also available.</td><!-- price comment -->
 </tr>
 
 <tr class="product NonFree NoSelfHosting NoE2EE NoFullE2EE NoAndroidSync NoPIMEncrypt NoDAV NoEmailEncrypt">
@@ -1376,10 +1363,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px tooltip">&euro;117<br />(30 GB)<span class="tooltiptext">Minimum 3 users who will get 30 GB each.</span></td>
-<td class="px tooltip">&euro;117<br />(100 GB)<span class="tooltiptext">Minimum 3 users who can share 100 GB.</span></td>
-<td class="px tooltip">&euro;223<br />(1 TB)<span class="tooltiptext">Minimum 3 users who can share 1 TB.</span></td>
-<td>Prices shown are for three users (team plans).</td><!-- price comment -->
+<td class="px tooltip">&euro;32<br />(10 GB)<span class="tooltiptext">Workplace Standard for 1 user (Teams with fewer than 3 users will get 10 GB per user). Also includes 30 GB for mail storage</span></td>
+<td colspan="2" class="px tooltip">&euro;65<br />(100 GB)<span class="tooltiptext">Workplace Professional for 1 user (Teams with fewer than 3 users will get 100 GB per user). Also includes 100 GB for mail storage</span></td>
+<td class="px tooltip">&euro;194<br />(1 TB)<span class="tooltiptext">Workplace Professional for 3 users who can share 1 TB. Also includes 100 GB for mail storage</span></td>
+<td></td><!-- price comment -->
 </tr>
 
 </table>
@@ -1396,10 +1383,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <ul>
 <li><strong>Apple iCloud</strong> (&euro;120 p.a. for 2 TB) <span class="bad">Big Tech</span> <span class="bad">Incompatible with Android and Linux</span> <span class="good">Opt-in E2EE for files</span></li>
 <li><strong>Google One</strong> (Drive &amp; Gmail) (&euro;100 p.a. for 2 TB) <span class="bad">Big Tech</span>   <span class="bad">No privacy</span> <span class="bad">Bond villains</span> <span class="bad">Incompatible with Linux</span></li>
-<li><strong>Microsoft 365</strong> (OneDrive &amp; Outlook.com) (&euro;69 p.a. for 1 TB files and 50 GB mail) <span class="bad">Big Tech</span>   <span class="bad">No privacy</span>  <span class="bad">Incompatible with Linux</span></li>
+<li><strong>Microsoft 365</strong> (OneDrive &amp; Outlook.com) (&euro;99 p.a. for 1 TB files and 100 GB for mail) <span class="bad">Big Tech</span>   <span class="bad">No privacy</span>  <span class="bad">Incompatible with Linux</span></li>
 <!-- <li><em>Further choices:</em><ul>
-<li><strong>GMX/Mail.com</strong> (&euro;96 p.a. for 500 GB files and 65 GB mail)   <span class="bad">No privacy</span> <span class="bad">No sync client</span> - if you care more about mail and PIM rather than file sync</li>
-<li><strong>Yandex</strong> (&euro;89 p.a. for 1 TB files and unlimited mail storage) <span class="bad">No privacy</span> - if you'd rather give your data to the Russians than the Americans</li> -->
+<li><strong>GMX/Mail.com</strong> (&euro;96 p.a. for 500 GB files and 65 GB for mail)   <span class="bad">No privacy</span> <span class="bad">No sync client</span> - if you care more about mail and PIM rather than file sync</li>
+<li><strong>Yandex</strong> (&euro;89 p.a. for 1 TB files and unlimited mail storage.) <span class="bad">No privacy</span> - if you'd rather give your data to the Russians than the Americans</li> -->
 </ul>
 </ul>
 
@@ -1420,15 +1407,15 @@ By the way, even if you use a non-private cloud provider, you can still encrypt 
 
 <ul>
 <li><strong>Murena</strong> (&euro;130 p.a. for 1 TB) <span class="good">Open Source</span></li>
-<li><strong>Infomaniak</strong> (kDrive &amp; Workspace) (&euro;60 p.a. for 2 TB) <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span></li>
-<li><strong>W&ouml;lkli</strong> Cloud &amp; Mail (&euro;391 for 5 GB mail + 50 GB files) <span class="good">Email with zero access encryption</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">Ridiculously expensive</span></li>
-<li><strong>Zoho Workspace</strong> (&euro;223 p.a. for 1 TB) - targets business users rather than private individuals</li>
+<li><strong>Infomaniak</strong> (kDrive &amp; Workspace) (&euro;79 p.a. for 3 TB) <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span></li>
+<li><strong>W&ouml;lkli</strong> Cloud &amp; Mail (&euro;416 p.a. for 5 GB for mail + 100 GB files) <span class="good">Email with zero access encryption</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">Ridiculously expensive</span></li>
+<li><strong>Zoho Workspace</strong> (&euro;194 p.a. for 1 TB) - targets business users rather than private individuals</li>
 <li><em>If you don't need a lot of cloud storage and are fine with just WebDAV access, these mail-focused providers could also be interesting:</em><ul>
-<li><strong>Fastmail</strong> (&euro;80 p.a. for 100 GB mail + 50 GB files)  <span class="bad">No file sync client</span></li>
-<li><strong>Kolab Now</strong> (&euro;385 p.a. for 100 GB) <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">No file sync client</span> <span class="bad">Expensive</span></li>
-<li><strong>Mailbox.org</strong> (&euro;121 p.a. for 100 GB) <span class="good">Email with zero access encryption</span> <span class="good">Open Source</span> <span class="bad">No file sync client</span></li>
-<li><strong>Mailfence</strong> (&euro;90 p.a. for 20 GB mail + 24 GB files) <span class="bad">No file sync client</span></li>
-<li><strong>Runbox</strong> (&euro;70 p.a. for 50 GB mail + 5 GB files) <span class="good">Open Source</span> <span class="bad">No file sync client</span></li>
+<li><strong>Fastmail</strong> (&euro;60 p.a. for 50 GB for mail + 10 GB for files)  <span class="bad">No file sync client</span></li>
+<li><strong>Kolab Now</strong> (&euro;442 p.a. for 100 GB) <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">No file sync client</span> <span class="bad">Expensive</span></li>
+<li><strong>Mailbox.org</strong> (&euro;114 p.a. for 100 GB) <span class="good">Email with zero access encryption</span> <span class="good">Open Source</span> <span class="bad">No file sync client</span></li>
+<li><strong>Mailfence</strong> (&euro;42 p.a. for 10 GB for mail + 30 GB files) <span class="bad">No file sync client</span></li>
+<li><strong>Runbox</strong> (&euro;80 p.a. for 50 GB for mail + 5 GB files) <span class="good">Open Source</span> <span class="bad">No file sync client</span></li>
 
 </ul>
 </ul>
@@ -1440,7 +1427,7 @@ By the way, even if you use a non-private cloud provider, you can still encrypt 
 <h4>Strategy 3a: E2EE one-stop solutions</h4>
 
 <ul>
-<li><strong>Proton</strong> (&euro;96 p.a. for 500 GB) <span class="good">E2EE</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">No ProtonDrive app for Linux</span> <span class="bad">Can't edit files in browser</span> <span class="bad">No CalDAV/CardDAV</span> <span class="bad">No tasks in calendar</span> <span class="bad">No IMAP on mobile</span></li>
+<li><strong>Proton</strong> (&euro;120 p.a. for 500 GB) <span class="good">E2EE</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">No ProtonDrive app for Linux</span> <span class="bad">Can't edit files in browser</span> <span class="bad">No CalDAV/CardDAV</span> <span class="bad">No tasks in calendar</span> <span class="bad">No IMAP on mobile</span></li>
 </ul>
 
 <p>Sadly, there is only one provider out there that offers a combination of mail hosting, calendar/contacts, and file cloud with all items fully end-to-end encrypted. That one provider is Proton Technologies. Unfortunately, while ProtonMail is a great and mature product, the other offerings (ProtonCalendar and ProtonDrive) are still rather immature.</span>
@@ -1449,12 +1436,12 @@ By the way, even if you use a non-private cloud provider, you can still encrypt 
 
 <!--
 <ul>
-<li>Variant 1 - best in class (&euro;121 p.a. for 15 GB mail + 2 TB files) </li>
+<li>Variant 1 - best in class (&euro;121 p.a. for 15 GB for mail + 2 TB files) </li>
 <ul>
 <li>For email: <strong>Proton</strong> <span class="good">E2EE</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">Forced to use their mobile app</span></li>
 <li>For contacts, calendar, and tasks: <strong>EteSync</strong> <span class="good">E2EE</span>  <span class="good">Open Source</span> <span class="bad">Buggy?</span></li>
 <li>For file sync: <strong>Mega</strong> <span class="good">E2EE</span>  <span class="good">API for 3rd-party apps</span> <span class="bad">Can't edit files in browser</span></li></ul>
-<li>Variant 2 - a bit cheaper (&euro;111 p.a. for 5 GB mail + 2 TB files)</li>
+<li>Variant 2 - a bit cheaper (&euro;111 p.a. for 5 GB for mail + 2 TB files)</li>
 <ul>
 <li>For email and contacts/calendar/tasks: <strong>Posteo</strong> <span class="good">Open Source</span> <span class="bad">Data will get temporarily decrypted</span> <span class="bad">No tasks in web interface</span> <span class="bad">Can't use your own domain for emails</span></li>
 <li>For file sync: <strong>Filen</strong>  <span class="good">E2EE</span> <span class="good">Open Source</span>  <span class="bad">No API for 3rd-party apps</span> <span class="bad">Can't edit files in browser</span></li>

--- a/cloud_comparison.htm
+++ b/cloud_comparison.htm
@@ -414,7 +414,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td colspan="2" class="px tooltip">&euro;60<br />(10 GB)<span class="tooltiptext">also includes 50 GB for mail storage</span></td>
+<td colspan="2" class="px tooltip">&euro;60<br />(10 GB)<span class="tooltiptext">also includes 50 GB mail storage</span></td>
 <td colspan="2" class="px na"></td>
 <td>Personal plan offers 50 GB for mail, calendar and contacts, and 10 GB for file storage. Family and duo plans are also offered.</td><!-- price comment -->
 </tr>
@@ -731,10 +731,10 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes <em><span class="tooltip">(needs PGP support in client)<span class="tooltiptext">To use encrypted mail (zero access encryption), the user will need to decrypt them on the local device, e.g. using Thunderbird, or the OpenKeychain app on Android</span></span></em></td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">&euro;30<br />(5 GB)<span class="tooltiptext">Standard plan. Also includes 10 GB for mail storage</span></td>
-<td class="px tooltip">&euro;40<br />(15 GB)<span class="tooltiptext">Standard plan. Also includes 10 GB for mail storage</span></td>
-<td class="px tooltip">&euro;114<br />(100 GB)<span class="tooltiptext">Premium plan. Also includes 25 GB for mail storage</span></td>
-<td class="px tooltip">&euro;546<br />(1 TB)<span class="tooltiptext">Premium plan. Also includes 25 GB for mail storage</span></td>
+<td class="px tooltip">&euro;30<br />(5 GB)<span class="tooltiptext">Standard plan. Also includes 10 GB mail storage</span></td>
+<td class="px tooltip">&euro;40<br />(15 GB)<span class="tooltiptext">Standard plan. Also includes 10 GB mail storage</span></td>
+<td class="px tooltip">&euro;114<br />(100 GB)<span class="tooltiptext">Premium plan. Also includes 25 GB mail storage</span></td>
+<td class="px tooltip">&euro;546<br />(1 TB)<span class="tooltiptext">Premium plan. Also includes 25 GB mail storage</span></td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -762,8 +762,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">&euro;30<br />(6 GB)<span class="tooltiptext">also includes 5 GB for mail storage</td>
-<td class="px tooltip">&euro;42<br />(30 GB)<span class="tooltiptext">also includes 10 GB for mail storage</td>
+<td class="px tooltip">&euro;30<br />(6 GB)<span class="tooltiptext">also includes 5 GB mail storage</td>
+<td class="px tooltip">&euro;42<br />(30 GB)<span class="tooltiptext">also includes 10 GB mail storage</td>
 <td colspan="2" class="px na"></td>
 <td></td><!-- price comment -->
 </tr>
@@ -819,9 +819,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">free<br />(5 GB)<span class="tooltiptext">also includes 15 GB for mail storage</span></td>
-<td colspan="2" class="px tooltip">&euro;20<br />(100 GB)<span class="tooltiptext">also includes 100 GB for mail storage</span></td>
-<td class="px tooltip">&euro;99<br />(1 TB)<span class="tooltiptext">also includes 100 GB for mail storage</span></td>
+<td class="px tooltip">free<br />(5 GB)<span class="tooltiptext">also includes 15 GB mail storage</span></td>
+<td colspan="2" class="px tooltip">&euro;20<br />(100 GB)<span class="tooltiptext">also includes 100 GB mail storage</span></td>
+<td class="px tooltip">&euro;99<br />(1 TB)<span class="tooltiptext">also includes 100 GB mail storage</span></td>
 <td>Family plan for 1-6 users also available. 1 TB plan & Family plan include Copilot (in case of the family plan, for subscription owner only) and Microsoft Office Online.</td><!-- price comment -->
 </tr>
 
@@ -1017,8 +1017,8 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="almost"><span class="tooltip">Desktop only<span class="tooltiptext">Windows, macOS, Linux</span></span><em> (via Proton&shy;Mail Bridge)</em></td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">free<br />(5 GB)<span class="tooltiptext">also includes 1 GB for mail storage</span></td>
-<td colspan="2" class="px tooltip">&euro;48<br />(200 GB)<span class="tooltiptext">also includes 1 GB for mail storage</span></td>
+<td class="px tooltip">free<br />(5 GB)<span class="tooltiptext">also includes 1 GB mail storage</span></td>
+<td colspan="2" class="px tooltip">&euro;48<br />(200 GB)<span class="tooltiptext">also includes 1 GB mail storage</span></td>
 <td class="px na"></td>
 <td>Proton also offers a 500GB plan for 120€ p.a. which also includes Proton Suite (Mail, VPN, Password Manager, AI Chatbot). Family and duo plans are also offered.</td><!-- price comment -->
 </tr>
@@ -1125,7 +1125,7 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="no">No</td>
 
 <td class="px">Free<br />(10 GB)</td>
-<td colspan="2" class="px">&euro; 96<br />(100 GB for mail + 100 GB files)</td>
+<td colspan="2" class="px">&euro; 96<br />(100 GB mail + 100 GB files)</td>
 <td class="px na"></td>
 <td></td>
 </tr>
@@ -1363,9 +1363,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <td class="yes">Yes</td><!-- IMAP -->
 <td class="yes">Yes</td><!-- Domain -->
 <!-- Prices: mail 5/15/50 Gb; files 20/100/500/1000/2000 GB -->
-<td class="px tooltip">&euro;32<br />(10 GB)<span class="tooltiptext">Workplace Standard for 1 user (Teams with fewer than 3 users will get 10 GB per user). Also includes 30 GB for mail storage</span></td>
-<td colspan="2" class="px tooltip">&euro;65<br />(100 GB)<span class="tooltiptext">Workplace Professional for 1 user (Teams with fewer than 3 users will get 100 GB per user). Also includes 100 GB for mail storage</span></td>
-<td class="px tooltip">&euro;194<br />(1 TB)<span class="tooltiptext">Workplace Professional for 3 users who can share 1 TB. Also includes 100 GB for mail storage</span></td>
+<td class="px tooltip">&euro;32<br />(10 GB)<span class="tooltiptext">Workplace Standard for 1 user (Teams with fewer than 3 users will get 10 GB per user). Also includes 30 GB mail storage</span></td>
+<td colspan="2" class="px tooltip">&euro;65<br />(100 GB)<span class="tooltiptext">Workplace Professional for 1 user (Teams with fewer than 3 users will get 100 GB per user). Also includes 100 GB mail storage</span></td>
+<td class="px tooltip">&euro;194<br />(1 TB)<span class="tooltiptext">Workplace Professional for 3 users who can share 1 TB. Also includes 100 GB mail storage</span></td>
 <td></td><!-- price comment -->
 </tr>
 
@@ -1383,9 +1383,9 @@ Here, I am looking at cloud services, which includes file sync, PIM (addressbook
 <ul>
 <li><strong>Apple iCloud</strong> (&euro;120 p.a. for 2 TB) <span class="bad">Big Tech</span> <span class="bad">Incompatible with Android and Linux</span> <span class="good">Opt-in E2EE for files</span></li>
 <li><strong>Google One</strong> (Drive &amp; Gmail) (&euro;100 p.a. for 2 TB) <span class="bad">Big Tech</span>   <span class="bad">No privacy</span> <span class="bad">Bond villains</span> <span class="bad">Incompatible with Linux</span></li>
-<li><strong>Microsoft 365</strong> (OneDrive &amp; Outlook.com) (&euro;99 p.a. for 1 TB files and 100 GB for mail) <span class="bad">Big Tech</span>   <span class="bad">No privacy</span>  <span class="bad">Incompatible with Linux</span></li>
+<li><strong>Microsoft 365</strong> (OneDrive &amp; Outlook.com) (&euro;99 p.a. for 1 TB files and 100 GB mail) <span class="bad">Big Tech</span>   <span class="bad">No privacy</span>  <span class="bad">Incompatible with Linux</span></li>
 <!-- <li><em>Further choices:</em><ul>
-<li><strong>GMX/Mail.com</strong> (&euro;96 p.a. for 500 GB files and 65 GB for mail)   <span class="bad">No privacy</span> <span class="bad">No sync client</span> - if you care more about mail and PIM rather than file sync</li>
+<li><strong>GMX/Mail.com</strong> (&euro;96 p.a. for 500 GB files and 65 GB mail)   <span class="bad">No privacy</span> <span class="bad">No sync client</span> - if you care more about mail and PIM rather than file sync</li>
 <li><strong>Yandex</strong> (&euro;89 p.a. for 1 TB files and unlimited mail storage.) <span class="bad">No privacy</span> - if you'd rather give your data to the Russians than the Americans</li> -->
 </ul>
 </ul>
@@ -1408,14 +1408,14 @@ By the way, even if you use a non-private cloud provider, you can still encrypt 
 <ul>
 <li><strong>Murena</strong> (&euro;130 p.a. for 1 TB) <span class="good">Open Source</span></li>
 <li><strong>Infomaniak</strong> (kDrive &amp; Workspace) (&euro;79 p.a. for 3 TB) <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span></li>
-<li><strong>W&ouml;lkli</strong> Cloud &amp; Mail (&euro;416 p.a. for 5 GB for mail + 100 GB files) <span class="good">Email with zero access encryption</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">Ridiculously expensive</span></li>
+<li><strong>W&ouml;lkli</strong> Cloud &amp; Mail (&euro;416 p.a. for 5 GB mail + 100 GB files) <span class="good">Email with zero access encryption</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">Ridiculously expensive</span></li>
 <li><strong>Zoho Workspace</strong> (&euro;194 p.a. for 1 TB) - targets business users rather than private individuals</li>
 <li><em>If you don't need a lot of cloud storage and are fine with just WebDAV access, these mail-focused providers could also be interesting:</em><ul>
-<li><strong>Fastmail</strong> (&euro;60 p.a. for 50 GB for mail + 10 GB for files)  <span class="bad">No file sync client</span></li>
+<li><strong>Fastmail</strong> (&euro;60 p.a. for 50 GB mail + 10 GB files)  <span class="bad">No file sync client</span></li>
 <li><strong>Kolab Now</strong> (&euro;442 p.a. for 100 GB) <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">No file sync client</span> <span class="bad">Expensive</span></li>
 <li><strong>Mailbox.org</strong> (&euro;114 p.a. for 100 GB) <span class="good">Email with zero access encryption</span> <span class="good">Open Source</span> <span class="bad">No file sync client</span></li>
-<li><strong>Mailfence</strong> (&euro;42 p.a. for 10 GB for mail + 30 GB files) <span class="bad">No file sync client</span></li>
-<li><strong>Runbox</strong> (&euro;80 p.a. for 50 GB for mail + 5 GB files) <span class="good">Open Source</span> <span class="bad">No file sync client</span></li>
+<li><strong>Mailfence</strong> (&euro;42 p.a. for 10 GB mail + 30 GB files) <span class="bad">No file sync client</span></li>
+<li><strong>Runbox</strong> (&euro;80 p.a. for 50 GB mail + 5 GB files) <span class="good">Open Source</span> <span class="bad">No file sync client</span></li>
 
 </ul>
 </ul>
@@ -1436,12 +1436,12 @@ By the way, even if you use a non-private cloud provider, you can still encrypt 
 
 <!--
 <ul>
-<li>Variant 1 - best in class (&euro;121 p.a. for 15 GB for mail + 2 TB files) </li>
+<li>Variant 1 - best in class (&euro;121 p.a. for 15 GB mail + 2 TB files) </li>
 <ul>
 <li>For email: <strong>Proton</strong> <span class="good">E2EE</span> <span class="good">Hosted in Switzerland</span> <span class="good">Open Source</span> <span class="bad">Forced to use their mobile app</span></li>
 <li>For contacts, calendar, and tasks: <strong>EteSync</strong> <span class="good">E2EE</span>  <span class="good">Open Source</span> <span class="bad">Buggy?</span></li>
 <li>For file sync: <strong>Mega</strong> <span class="good">E2EE</span>  <span class="good">API for 3rd-party apps</span> <span class="bad">Can't edit files in browser</span></li></ul>
-<li>Variant 2 - a bit cheaper (&euro;111 p.a. for 5 GB for mail + 2 TB files)</li>
+<li>Variant 2 - a bit cheaper (&euro;111 p.a. for 5 GB mail + 2 TB files)</li>
 <ul>
 <li>For email and contacts/calendar/tasks: <strong>Posteo</strong> <span class="good">Open Source</span> <span class="bad">Data will get temporarily decrypted</span> <span class="bad">No tasks in web interface</span> <span class="bad">Can't use your own domain for emails</span></li>
 <li>For file sync: <strong>Filen</strong>  <span class="good">E2EE</span> <span class="good">Open Source</span>  <span class="bad">No API for 3rd-party apps</span> <span class="bad">Can't edit files in browser</span></li>

--- a/index.html
+++ b/index.html
@@ -304,7 +304,7 @@ img.invert {
       <div class="image-wrapper"><img src="pics/logos/cloud/zoho.png" /></div>
     </div>
   </div>
-  <p> <span class="gold">(last update: April 2026)</span>
+  <p> <span class="gold">(last update: May 2026)</span>
   <br/>Who can compete with Apple, Microsoft and Google while offering more privacy and features? Comparison of about 40 different providers with some recommendations at the end </p>
   </div>
 


### PR DESCRIPTION
- Updated all prices found in the "[Cloud, Sync & Email Services - Comparison Table](https://eylenburg.github.io/cloud_comparison.htm)" to match May 2026 prices.

- Changed all storage quotas to match the drive product the provider offers as previously it wasn't consistent - some reported the drive quota while others reported the mail one. The mail quota is still there in the form of a tooltip, so if you hover over the drive quota it also shows you the mail one (if they offer one).

- Added additional services that a provider offers on certain plans (such as Copilot for M365 or the Proton Suite for Proton) in the `Comment` section, and specified that all prices are VAT excluded.

- If a provider doesn't offer anything for a certain bracket, the first available bracket now takes up the space of the previous ones (for all the providers, not just a few like before). For instance Dropbox doesn't offer anything below 2TB, so I made it so that all 4 brackets (≥5GB, ≥15GB, ≥100GB, ≥1TB) are taken up by the 2TB one (attached a screenshot for easier understanding). Let me know if I should revert this and make it so that all of the brackets without an offer are empty. <img width="1833" height="258" alt="image" src="https://github.com/user-attachments/assets/0481f3a7-ef0e-4b5f-a9c2-c14a2ed5f7a3" />