### PR TITLE
Debian supports secure boot out of the box

### DIFF
--- a/linux_comparison.htm
+++ b/linux_comparison.htm
@@ -1444,7 +1444,7 @@ Distributions mostly differ in their package manager and their default choices (
 
 <tr>
 <td class="legend">Out-of-the-box support for Secure Boot</td>
-<td class="no tooltip">No<span class="tooltiptext">While Debian does support Secure Boot, you'll have to enroll your own MOK certificate and sign the kernel yourself. That also means you cannot install Debian without first disabling Secure Boot. On the other hand, Ubuntu, Fedora/RHEL and OpenSUSE/SLE offer Secure Boot working out of the box with most x86 systems without any fiddling.</span></td>
+<td class="yes">Yes</td>
 <td class="yes">Yes</td>
 <td class="yes">Yes</td>
 <td class="yes">Yes</td>


### PR DESCRIPTION
I'm not sure when it was required to explicitly enrol MOK keys, but this is not required anymore and hasn't been for years.

Debian also supports secure boot when custom kernel modules are installed via DKMS, with a semi-automated MOK procedure. Not sure if other distributions besides Ubuntu have this (since this was developed first in Ubuntu and then upstreamed in dkms).