### PR TITLE
apt supports history-rollback

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@ div.article {
       <div class="image-wrapper"><img src="pics/logos/distros/solus.png"  /></div>
     </div>
   </div>
-  <p> <span class="gold">(last update: April 2026)</span>
+  <p> <span class="gold">(last update: August 2026)</span>
   <br />Comparison of almost 17 (actually 19) Linux distributions: Debian, Ubuntu, openSUSE Tumbleweed &amp; openSUSE MicroOS, SUSE Linux Enterprise, Fedora Workstation &amp; Fedora Atomic Desktop, Red Hat Enterprise Linux, OpenMandriva ROME, Mageia, PCLinuxOS, Arch, Slackware, Gentoo, Alpine, Void, NixOS, Guix System, and Solus.
   <br /><br />In the Appendix: <strong>How heterogeneous are the distributions today and how heterogeneous have they been historically?</strong> Looking at the most important distributions and their choice of desktop environment, widget toolkit, display server, package format, file system, init sofware, and security module from the year 2000 until today.
   </div>

--- a/linux_comparison.htm
+++ b/linux_comparison.htm
@@ -139,7 +139,7 @@ Distributions mostly differ in their package manager and their default choices (
 
 <h2 class="center">Comparison of Linux Distributions</h2>
 <p class="center">Source: eylenburg.github.io</p>
-<p class="center" style="color: red; font-size: small;">Last updated: 16 April 2026</p>
+<p class="center" style="color: red; font-size: small;">Last updated: 20 August 2026</p>
 <p style="font-size: 75%; font-style: italic;"> This table is best viewed on a monitor with 1920px width (Full HD) with 100% display scaling.</p>
 
 <div>

--- a/linux_comparison.htm
+++ b/linux_comparison.htm
@@ -483,7 +483,7 @@ Distributions mostly differ in their package manager and their default choices (
 
 <tr>
 <td class="legend">Ability to roll back updates?</td>
-<td class="no">No</td>
+<td class="yes tooltip"><code>apt history-rollback</code><span class="tooltiptext">Packages are installed or removed according to a previous transaction, but leftovers from previously installed packages could remain on the system</span></td>
 <td class="no">No</td>
 <td class="yes" span style="font-size: x-small;"><code>snapper rollback</code></td>
 <td class="yes" span style="font-size: x-small;"><code>snapper rollback</code></td>


### PR DESCRIPTION
This allows to roll back updates, and package installation/removal in general. This does not involve filesystem snapshotting though, and is hence more simple and limited in what it can do.

I considered using `class="mixed"` instead of `class="yes"`, but Solus' system seems equivalent and is marked with `class="yes"`.